### PR TITLE
remove link to missing "latest sic call" page

### DIFF
--- a/src/development/sic-calls/intro.md
+++ b/src/development/sic-calls/intro.md
@@ -10,4 +10,4 @@ The calls are open, so anyone is welcome to join!
 
 ## Previous calls
 
-You can see summaries and call recordings in the [lastest](./lastest.md) and [history](./history.md) pages.
+You can see summaries and call recordings in the [history](./history.md) page.


### PR DESCRIPTION
The "intro" page of the SIC history is pointing to a missing page. I suggest removing it, as we are giving direct links to the history page from the twitter account anyway, and summaries are provided in reverse-chronological order. If the main page becomes too big, we can move the very old calls to a "archive" page later on.